### PR TITLE
Update Terraform required version constraint to allow 1.5.x

### DIFF
--- a/examples/private/versions.tf
+++ b/examples/private/versions.tf
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.0, <= 1.5.5"
+  required_version = "~> 1.5"
 
   required_providers {
     azurerm = {

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.0, <= 1.5.5"
+  required_version = "~> 1.5"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
Update version constraint to allow for ~> 1.5

Setting version 1.5 as the supported minimum version as much of the "optional" variable construction in use is not fully supported until 1.5